### PR TITLE
Fix: Objects not loaded after repeated put #11

### DIFF
--- a/src/hashtable.cpp
+++ b/src/hashtable.cpp
@@ -142,8 +142,11 @@ Handle<Value> HashTable::Put(const Arguments& args) {
 
     HashTable *obj = ObjectWrap::Unwrap<HashTable>(args.This());
 
-    Persistent<Value> key = Persistent<Value>::New(args[0]);
-    Persistent<Value> value = Persistent<Value>::New(args[1]);
+    Local<Value> localk = Local<Value>::New(args[0]);
+    Local<Value> localv = Local<Value>::New(args[1]);
+
+    Persistent<Value> key = Persistent<Value>::New(localk);
+    Persistent<Value> value = Persistent<Value>::New(localv);
 
     MapType::const_iterator itr = obj->map.find(key);
 


### PR DESCRIPTION
Similar bugs founded in my project. (ref issue #11)

It seems that Local<Value>:New(args[0]) will be freed by v8 in a very
bad way (which is, the underlying storage is freed, while the ptr is
still in hold).

So I just looked at the commit history and fixed it by using the
copy-to-local first strategy. Currently this seems work in my place, and
should work other place. It is safer, slower, but it make 0.4.\* branch work.
