### PR TITLE
Fix: Objects not loaded after repeated put #11

### DIFF
--- a/src/hashtable.cpp
+++ b/src/hashtable.cpp
@@ -151,6 +151,7 @@ Handle<Value> HashTable::Put(const Arguments& args) {
     if(itr != obj->map.end()) {
         Persistent<Value> oldValue = itr->second;
         oldValue.Dispose(); //release the handle to the GC
+        obj->map.erase(itr);
     }
 
     obj->map.insert(std::pair<Persistent<Value>, Persistent<Value> >(key, value));


### PR DESCRIPTION
v8 Dispose must have done memory critical operation and make the cpp
iterator not work as expected. The solution is to properly delete the
key-value pair before insert the new one.