### PR TITLE
fix issues with recent clang on macOS (tr1 removed)

### DIFF
--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -3,7 +3,7 @@
 
 #include <string>
 #include <iostream>
-#ifdef __APPLE__
+#if defined __APPLE__ && __cplusplus < 201103L
 #include <tr1/unordered_map>
 #define unordered_map std::tr1::unordered_map
 #else

--- a/src/v8_value_hasher.h
+++ b/src/v8_value_hasher.h
@@ -4,7 +4,7 @@
 #include <string>
 #include <iostream>
 #include <node.h>
-#ifdef __APPLE__
+#if defined __APPLE__ && __cplusplus < 201103L
 #include <tr1/unordered_set>
 #define hash std::tr1::hash
 #else


### PR DESCRIPTION
hashtable does not compile on recent macOS:

```
> hashtable@2.0.2 install /Users/fbenhamo/tmp/node-hashtable
> node-gyp configure build

  CXX(target) Release/obj.target/native/src/hashtable.o
In file included from ../src/hashtable.cpp:1:
../src/hashtable.h:7:10: fatal error: 'tr1/unordered_map' file not found
#include <tr1/unordered_map>
         ^
1 error generated.
```

This is a fix for this issue.