### PR TITLE
This will fix the build for macOS Sierra (OS X 10.12).

### DIFF
--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -4,12 +4,16 @@
 #include <string>
 #include <iostream>
 #ifdef __APPLE__
+#include <AvailabilityMacros.h>
+#endif
+#if defined(__APPLE__) && !defined(MAC_OS_X_VERSION_10_12)
 #include <tr1/unordered_map>
 #define unordered_map std::tr1::unordered_map
 #else
 #include <unordered_map>
 #define unordered_map std::unordered_map
 #endif
+
 #include <node.h>
 #include <nan.h>
 #include "v8_value_hasher.h"

--- a/src/v8_value_hasher.h
+++ b/src/v8_value_hasher.h
@@ -5,6 +5,9 @@
 #include <iostream>
 #include <node.h>
 #ifdef __APPLE__
+#include <AvailabilityMacros.h>
+#endif
+#if defined(__APPLE__) && !defined(MAC_OS_X_VERSION_10_12)
 #include <tr1/unordered_set>
 #define hash std::tr1::hash
 #else


### PR DESCRIPTION
In OS X 10.12 Apple dropped the tr1 folder for c++11 includes.
